### PR TITLE
Fix whofaved_deviation by changing to get_data

### DIFF
--- a/deviantart/api.py
+++ b/deviantart/api.py
@@ -357,7 +357,7 @@ class Api(object):
         :param limit: the pagination limit
         """
 
-        response = self._req('/deviation/whofaved', post_data={
+        response = self._req('/deviation/whofaved', get_data={
             'deviationid' : deviationid,
             'offset' : offset,
             'limit' : limit


### PR DESCRIPTION
`whofaved_deviation` will always return with the default pagination parameters -- `offset = 0`, `limit = 10` -- as written, because the parameters to the request are written to the `post_data` struct even though this is a `GET` request. 

That was probably a small oversight that should be fixed with this one line of change.